### PR TITLE
add JsonReader

### DIFF
--- a/typed.go
+++ b/typed.go
@@ -3,6 +3,7 @@ package typed
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"time"
 )
@@ -36,6 +37,15 @@ func Must(data []byte) Typed {
 		panic(err)
 	}
 	return Typed(m)
+}
+
+// Create a Typed helper from the given JSON stream
+func JsonStream(reader io.Reader) (Typed, error) {
+	if data, err := ioutil.ReadAll(reader); err != nil {
+		return nil, err
+	} else {
+		return Json(data)
+	}
 }
 
 // Create a Typed helper from the given JSON string

--- a/typed.go
+++ b/typed.go
@@ -40,7 +40,7 @@ func Must(data []byte) Typed {
 }
 
 // Create a Typed helper from the given JSON stream
-func JsonStream(reader io.Reader) (Typed, error) {
+func JsonReader(reader io.Reader) (Typed, error) {
 	if data, err := ioutil.ReadAll(reader); err != nil {
 		return nil, err
 	} else {

--- a/typed_test.go
+++ b/typed_test.go
@@ -1,14 +1,25 @@
 package typed
 
 import (
-	. "github.com/karlseguin/expect"
+	"bytes"
 	"testing"
+
+	. "github.com/karlseguin/expect"
 )
 
 type TypedTests struct{}
 
 func Test_Typed(t *testing.T) {
 	Expectify(new(TypedTests), t)
+}
+
+func (_ TypedTests) JsonStream() {
+	json := []byte(`{"power": 9002}`)
+	stream := bytes.NewBuffer(json)
+
+	typed, err := JsonStream(stream)
+	Expect(typed.Int("power")).To.Equal(9002)
+	Expect(err).To.Equal(nil)
 }
 
 func (_ TypedTests) Json() {

--- a/typed_test.go
+++ b/typed_test.go
@@ -13,11 +13,11 @@ func Test_Typed(t *testing.T) {
 	Expectify(new(TypedTests), t)
 }
 
-func (_ TypedTests) JsonStream() {
+func (_ TypedTests) JsonReader() {
 	json := []byte(`{"power": 9002}`)
 	stream := bytes.NewBuffer(json)
 
-	typed, err := JsonStream(stream)
+	typed, err := JsonReader(stream)
 	Expect(typed.Int("power")).To.Equal(9002)
 	Expect(err).To.Equal(nil)
 }


### PR DESCRIPTION
Adds support to create a `Typed` instance from a json stream. We are using it to in many http handlers:

``` go
func (this Server) handlePost(response http.ResponseWriter, request *http.Request) {
     body, err := typed.JsonReader(request.Body)

     // ...
}
```