### PR TITLE
Fix json unmarshalling number precision by UseNumber

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/karlseguin/typed
+
+go 1.15
+
+require github.com/karlseguin/expect v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/karlseguin/expect v1.0.7 h1:OF4mqjblc450v8nKARBS5Q0AweBNR0A+O3VjjpxwBrg=
+github.com/karlseguin/expect v1.0.7/go.mod h1:lXdI8iGiQhmzpnnmU/EGA60vqKs8NbRNFnhhrJGoD5g=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=

--- a/typed_test.go
+++ b/typed_test.go
@@ -14,17 +14,17 @@ func Test_Typed(t *testing.T) {
 }
 
 func (_ TypedTests) JsonReader() {
-	json := []byte(`{"power": 9002}`)
+	json := []byte(`{"power": 8988876781182962205}`)
 	stream := bytes.NewBuffer(json)
 
 	typed, err := JsonReader(stream)
-	Expect(typed.Int("power")).To.Equal(9002)
+	Expect(typed.Int("power")).To.Equal(8988876781182962205)
 	Expect(err).To.Equal(nil)
 }
 
 func (_ TypedTests) Json() {
-	typed, err := Json([]byte(`{"power": 9002}`))
-	Expect(typed.Int("power")).To.Equal(9002)
+	typed, err := Json([]byte(`{"power": 8988876781182962205}`))
+	Expect(typed.Int("power")).To.Equal(8988876781182962205)
 	Expect(err).To.Equal(nil)
 }
 


### PR DESCRIPTION
Context: Unmarshalling JSON number will always result in floats. If the origin integers are big, the result floats will have scienctific notation, which will cause precision error when casting to int.

Solution: Json decoder `UseNumber` will preserve the precision.

Misc: This pull request also introduces Go mod for easier deps management.